### PR TITLE
ARM: make sure __on_dlclose() actually gets called

### DIFF
--- a/libc/arch-arm/bionic/crtbegin_so.c
+++ b/libc/arch-arm/bionic/crtbegin_so.c
@@ -29,7 +29,7 @@
 extern void __cxa_finalize(void *);
 extern void *__dso_handle;
 
-__attribute__((visbility("hidden")))
+__attribute__((visibility("hidden"),destructor))
 void __on_dlclose() {
   __cxa_finalize(&__dso_handle);
 }


### PR DESCRIPTION
Change-Id: I280e5428b0543cccf17ca36baee4865395928cdb
Signed-off-by: Ard Biesheuvel ard.biesheuvel@gmail.com

Juan Gómez: Fixes Bug 1108228
